### PR TITLE
feat: Add dynamic KubeSizeID selection with optional osImageID

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -114,6 +114,8 @@ func addFlags(cmd *cobra.Command, opts *controller.Options) {
 		"VPSie Kubernetes cluster identifier for dynamic NodeGroup creation")
 	flags.StringVar(&opts.KubernetesVersion, "kubernetes-version", opts.KubernetesVersion,
 		"Kubernetes version for dynamic NodeGroups (e.g., v1.34.1)")
+	flags.IntVar(&opts.KubeSizeID, "kube-size-id", opts.KubeSizeID,
+		"VPSie Kubernetes size/package ID for dynamic NodeGroups (from k8s/offers API)")
 
 	// Logging configuration
 	flags.StringVar(&opts.LogLevel, "log-level", opts.LogLevel,

--- a/deploy/crds/autoscaler.vpsie.com_nodegroups.yaml
+++ b/deploy/crds/autoscaler.vpsie.com_nodegroups.yaml
@@ -197,7 +197,9 @@ spec:
                 minItems: 1
                 type: array
               osImageID:
-                description: OSImageID is the VPSie OS image ID to use for new nodes
+                description: |-
+                  OSImageID is the VPSie OS image ID to use for new nodes
+                  Optional: VPSie API will automatically select an appropriate OS image if not specified
                 type: string
               preferredInstanceType:
                 description: PreferredInstanceType is the preferred offering ID to
@@ -378,7 +380,6 @@ spec:
             - maxNodes
             - minNodes
             - offeringIDs
-            - osImageID
             - project
             - resourceIdentifier
             type: object

--- a/deploy/crds/autoscaler.vpsie.com_vpsienodes.yaml
+++ b/deploy/crds/autoscaler.vpsie.com_vpsienodes.yaml
@@ -97,7 +97,9 @@ spec:
                   If not specified, it will be automatically generated
                 type: string
               osImageID:
-                description: OSImageID is the VPSie OS image ID to use for this node
+                description: |-
+                  OSImageID is the VPSie OS image ID to use for this node
+                  Optional: VPSie API will automatically select an appropriate OS image if not specified
                 type: string
               project:
                 description: Project is the VPSie project ID
@@ -124,7 +126,6 @@ spec:
             - instanceType
             - kubernetesVersion
             - nodeGroupName
-            - osImageID
             - project
             - resourceIdentifier
             - vpsieInstanceID

--- a/deploy/manifests/deployment.yaml
+++ b/deploy/manifests/deployment.yaml
@@ -28,7 +28,7 @@ spec:
       - name: ghcr-secret
       containers:
       - name: controller
-        image: ghcr.io/vpsieinc/vpsie-k8s-autoscaler:0.7.3
+        image: ghcr.io/vpsieinc/vpsie-k8s-autoscaler:0.7.8
         imagePullPolicy: Always
         command:
         - /vpsie-autoscaler
@@ -41,6 +41,7 @@ spec:
         - --default-offering-ids=360a7d29-7ca9-11ee-8bba-0050569c68dc,3af1b942-7ca9-11ee-8bba-0050569c68dc
         - --resource-identifier=567ee954-3b83-4912-8d74-ba47601f1cf6
         - --kubernetes-version=v1.34.1
+        # Note: --kube-size-id is now optional - KubeSizeID is dynamically selected based on pod resources
         ports:
         - name: metrics
           containerPort: 8080

--- a/docs/TODO_WORKAROUNDS.md
+++ b/docs/TODO_WORKAROUNDS.md
@@ -1,0 +1,54 @@
+# Temporary Workarounds
+
+This document tracks temporary workarounds implemented due to external limitations that should be removed once the limitations are fixed.
+
+## VPSie Node Group Size Limitation
+
+**Status:** Active workaround
+**Added:** 2026-01-11
+**File:** `pkg/events/creator.go` - `SelectOptimalKubeSizeID()`
+
+### Issue
+
+VPSie API currently does not allow multiple node groups with the same `kubeSizeID` (BoxsizeID) in a Kubernetes cluster. Attempting to create a second node group with a size that's already in use returns:
+
+```
+Group GRP-Advanced-c745 has same selected Size, please select another size
+```
+
+### Workaround
+
+The `SelectOptimalKubeSizeID()` function now:
+
+1. Fetches existing VPSie node groups via `ListK8sNodeGroups()`
+2. Collects the `BoxsizeID` values that are already in use
+3. Filters out these sizes when selecting the optimal KubeSizeID for a new node group
+4. Falls back to the next available size if the optimal size is already in use
+
+### Code Location
+
+```go
+// pkg/events/creator.go
+
+// Get existing node groups to find sizes already in use (VPSie limitation workaround)
+usedSizes := make(map[int]bool)
+if c.template.ResourceIdentifier != "" {
+    existingGroups, err := c.vpsieClient.ListK8sNodeGroups(ctx, c.template.ResourceIdentifier)
+    // ... filter out used sizes
+}
+```
+
+### When to Remove
+
+Remove this workaround when VPSie fixes their API to allow multiple node groups with the same size. After removal:
+
+1. Remove the `ListK8sNodeGroups()` call in `SelectOptimalKubeSizeID()`
+2. Remove the `usedSizes` filtering logic
+3. Simplify the selection to just pick the optimal size based on pod resources
+4. Update this document to mark the workaround as removed
+
+### Impact
+
+- Slight performance overhead due to extra API call to list existing node groups
+- If all sizes are in use, node group creation will fail with an error message
+- Users may get larger (more expensive) nodes than optimal if smaller sizes are already in use

--- a/pkg/apis/autoscaler/v1alpha1/nodegroup_types.go
+++ b/pkg/apis/autoscaler/v1alpha1/nodegroup_types.go
@@ -38,8 +38,9 @@ type NodeGroupSpec struct {
 	OfferingIDs []string `json:"offeringIDs"`
 
 	// OSImageID is the VPSie OS image ID to use for new nodes
-	// +kubebuilder:validation:Required
-	OSImageID string `json:"osImageID"`
+	// Optional: VPSie API will automatically select an appropriate OS image if not specified
+	// +kubebuilder:validation:Optional
+	OSImageID string `json:"osImageID,omitempty"`
 
 	// KubernetesVersion is the Kubernetes version to install on new nodes (e.g., "v1.28.0", "v1.29.1")
 	// Must be within ±1 minor version of the control plane

--- a/pkg/apis/autoscaler/v1alpha1/vpsienode_types.go
+++ b/pkg/apis/autoscaler/v1alpha1/vpsienode_types.go
@@ -31,8 +31,9 @@ type VPSieNodeSpec struct {
 	Project string `json:"project"`
 
 	// OSImageID is the VPSie OS image ID to use for this node
-	// +kubebuilder:validation:Required
-	OSImageID string `json:"osImageID"`
+	// Optional: VPSie API will automatically select an appropriate OS image if not specified
+	// +kubebuilder:validation:Optional
+	OSImageID string `json:"osImageID,omitempty"`
 
 	// KubernetesVersion is the Kubernetes version to install on this node (e.g., "v1.28.0")
 	// +kubebuilder:validation:Pattern=`^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$`

--- a/pkg/controller/nodegroup/status.go
+++ b/pkg/controller/nodegroup/status.go
@@ -197,9 +197,7 @@ func ValidateNodeGroupSpec(ng *v1alpha1.NodeGroup) error {
 		return fmt.Errorf("at least one offeringID is required")
 	}
 
-	if ng.Spec.OSImageID == "" {
-		return fmt.Errorf("osImageID is required")
-	}
+	// OSImageID is optional - VPSie API will automatically select an appropriate OS image
 
 	if ng.Spec.KubernetesVersion == "" {
 		return fmt.Errorf("kubernetesVersion is required")

--- a/pkg/controller/options.go
+++ b/pkg/controller/options.go
@@ -63,6 +63,10 @@ type Options struct {
 
 	// KubernetesVersion is the Kubernetes version for dynamic NodeGroups (e.g., "v1.34.1")
 	KubernetesVersion string
+
+	// KubeSizeID is the VPSie Kubernetes size/package ID for dynamic NodeGroups
+	// Get available IDs from the k8s/offers API endpoint
+	KubeSizeID int
 }
 
 // NewDefaultOptions returns Options with default values
@@ -85,6 +89,7 @@ func NewDefaultOptions() *Options {
 		DefaultOfferingIDs:      nil, // Must be set for dynamic NodeGroup creation
 		ResourceIdentifier:      "",  // Must be set for dynamic NodeGroup creation
 		KubernetesVersion:       "",  // Must be set for dynamic NodeGroup creation
+		KubeSizeID:              0,   // Must be set for dynamic NodeGroup creation
 	}
 }
 

--- a/pkg/events/creator.go
+++ b/pkg/events/creator.go
@@ -3,24 +3,28 @@ package events
 import (
 	"context"
 	"fmt"
+	"sort"
 	"time"
 
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/vpsie/vpsie-k8s-autoscaler/pkg/apis/autoscaler/v1alpha1"
 	"github.com/vpsie/vpsie-k8s-autoscaler/pkg/metrics"
+	vpsieclient "github.com/vpsie/vpsie-k8s-autoscaler/pkg/vpsie/client"
 )
 
 // DynamicNodeGroupCreator creates NodeGroups dynamically when no suitable managed NodeGroup exists.
 // Created NodeGroups are always marked with the managed label (autoscaler.vpsie.com/managed=true)
 // to ensure they are processed by the autoscaler.
 type DynamicNodeGroupCreator struct {
-	client   client.Client
-	logger   *zap.Logger
-	template *NodeGroupTemplate
+	client      client.Client
+	vpsieClient *vpsieclient.Client
+	logger      *zap.Logger
+	template    *NodeGroupTemplate
 }
 
 // NodeGroupTemplate provides default values for dynamically created NodeGroups
@@ -51,6 +55,9 @@ type NodeGroupTemplate struct {
 
 	// KubernetesVersion is the Kubernetes version to install on new nodes
 	KubernetesVersion string
+
+	// KubeSizeID is the VPSie Kubernetes size/package ID (from k8s/offers endpoint)
+	KubeSizeID int
 }
 
 // DefaultNodeGroupTemplate returns a template with sensible defaults
@@ -65,12 +72,14 @@ func DefaultNodeGroupTemplate() *NodeGroupTemplate {
 		Project:             "",
 		OSImageID:           "",
 		KubernetesVersion:   "",
+		KubeSizeID:          0,
 	}
 }
 
 // NewDynamicNodeGroupCreator creates a new DynamicNodeGroupCreator
 func NewDynamicNodeGroupCreator(
 	client client.Client,
+	vpsieClient *vpsieclient.Client,
 	logger *zap.Logger,
 	template *NodeGroupTemplate,
 ) *DynamicNodeGroupCreator {
@@ -79,9 +88,10 @@ func NewDynamicNodeGroupCreator(
 	}
 
 	return &DynamicNodeGroupCreator{
-		client:   client,
-		logger:   logger.Named("dynamic-nodegroup-creator"),
-		template: template,
+		client:      client,
+		vpsieClient: vpsieClient,
+		logger:      logger.Named("dynamic-nodegroup-creator"),
+		template:    template,
 	}
 }
 
@@ -193,6 +203,12 @@ func (c *DynamicNodeGroupCreator) CreateNodeGroupForPod(
 		namespace = c.template.Namespace
 	}
 
+	// Select optimal KubeSizeID based on pod's resource requirements
+	kubeSizeID, err := c.SelectOptimalKubeSizeID(ctx, pod, c.template.DefaultDatacenterID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to select KubeSizeID: %w", err)
+	}
+
 	// Generate unique name
 	name := c.generateNodeGroupName()
 
@@ -200,10 +216,13 @@ func (c *DynamicNodeGroupCreator) CreateNodeGroupForPod(
 		zap.String("nodeGroup", name),
 		zap.String("pod", pod.Name),
 		zap.String("namespace", namespace),
+		zap.Int("kubeSizeID", kubeSizeID),
 	)
 
 	// Build NodeGroup spec based on pod requirements
 	spec := c.buildNodeGroupSpec(pod)
+	// Override with dynamically selected KubeSizeID
+	spec.KubeSizeID = kubeSizeID
 
 	ng := &v1alpha1.NodeGroup{
 		ObjectMeta: metav1.ObjectMeta{
@@ -229,6 +248,7 @@ func (c *DynamicNodeGroupCreator) CreateNodeGroupForPod(
 		zap.String("namespace", namespace),
 		zap.Int32("minNodes", spec.MinNodes),
 		zap.Int32("maxNodes", spec.MaxNodes),
+		zap.Int("kubeSizeID", spec.KubeSizeID),
 	)
 
 	return ng, nil
@@ -258,6 +278,7 @@ func (c *DynamicNodeGroupCreator) buildNodeGroupSpec(pod *corev1.Pod) v1alpha1.N
 		Project:            c.template.Project,
 		OSImageID:          c.template.OSImageID,
 		KubernetesVersion:  c.template.KubernetesVersion,
+		KubeSizeID:         c.template.KubeSizeID,
 	}
 
 	// Copy node selector labels to NodeGroup spec
@@ -337,4 +358,168 @@ func (c *DynamicNodeGroupCreator) SetTemplate(template *NodeGroupTemplate) {
 	if template != nil {
 		c.template = template
 	}
+}
+
+// SelectOptimalKubeSizeID selects the most cost-effective KubeSizeID that can accommodate
+// the pod's resource requirements. It fetches K8s offers from VPSie API and selects the
+// smallest (cheapest) size that can satisfy the pod's CPU and memory requests.
+// It also checks existing VPSie node groups to avoid selecting sizes already in use
+// (VPSie limitation: only one node group per size allowed).
+func (c *DynamicNodeGroupCreator) SelectOptimalKubeSizeID(
+	ctx context.Context,
+	pod *corev1.Pod,
+	datacenterID string,
+) (int, error) {
+	if c.vpsieClient == nil {
+		// Fallback to template's static KubeSizeID if no VPSie client
+		if c.template.KubeSizeID > 0 {
+			c.logger.Debug("Using static KubeSizeID from template (no VPSie client)",
+				zap.Int("kubeSizeID", c.template.KubeSizeID))
+			return c.template.KubeSizeID, nil
+		}
+		return 0, fmt.Errorf("no VPSie client available and no static KubeSizeID configured")
+	}
+
+	// Fetch available K8s offers from VPSie API
+	offers, err := c.vpsieClient.ListK8sOffers(ctx, datacenterID)
+	if err != nil {
+		// Fallback to template's static KubeSizeID on API error
+		if c.template.KubeSizeID > 0 {
+			c.logger.Warn("Failed to fetch K8s offers, using static KubeSizeID",
+				zap.Error(err),
+				zap.Int("kubeSizeID", c.template.KubeSizeID))
+			return c.template.KubeSizeID, nil
+		}
+		return 0, fmt.Errorf("failed to fetch K8s offers: %w", err)
+	}
+
+	if len(offers) == 0 {
+		return 0, fmt.Errorf("no K8s offers available in datacenter %s", datacenterID)
+	}
+
+	// Get existing node groups to find sizes already in use (VPSie limitation workaround)
+	usedSizes := make(map[int]bool)
+	if c.template.ResourceIdentifier != "" {
+		existingGroups, err := c.vpsieClient.ListK8sNodeGroups(ctx, c.template.ResourceIdentifier)
+		if err != nil {
+			c.logger.Warn("Failed to fetch existing node groups, proceeding without filter",
+				zap.Error(err))
+		} else {
+			for _, group := range existingGroups {
+				usedSizes[group.BoxsizeID] = true
+			}
+			if len(usedSizes) > 0 {
+				c.logger.Info("Found existing VPSie node groups with sizes in use",
+					zap.Int("usedSizeCount", len(usedSizes)),
+					zap.Any("usedSizes", usedSizes),
+				)
+			}
+		}
+	}
+
+	// Calculate pod's resource requirements
+	cpuRequest, memoryRequest := c.calculatePodResources(pod)
+
+	c.logger.Info("Selecting optimal KubeSizeID for pod resources",
+		zap.String("pod", pod.Name),
+		zap.String("cpuRequest", cpuRequest.String()),
+		zap.String("memoryRequest", memoryRequest.String()),
+		zap.Int("availableOffers", len(offers)),
+		zap.Int("usedSizes", len(usedSizes)),
+	)
+
+	// Sort offers by price (ascending) to prefer cheaper options
+	sortedOffers := make([]vpsieclient.K8sOffer, len(offers))
+	copy(sortedOffers, offers)
+	sort.Slice(sortedOffers, func(i, j int) bool {
+		return sortedOffers[i].Price < sortedOffers[j].Price
+	})
+
+	// Find the cheapest offer that can accommodate the pod AND is not already in use
+	cpuMillis := cpuRequest.MilliValue()
+	memoryMB := memoryRequest.Value() / (1024 * 1024) // Convert bytes to MB
+
+	for _, offer := range sortedOffers {
+		// Skip sizes already in use (VPSie limitation workaround)
+		if usedSizes[offer.ID] {
+			c.logger.Debug("Skipping size already in use",
+				zap.Int("kubeSizeID", offer.ID),
+				zap.String("name", offer.Name),
+			)
+			continue
+		}
+
+		offerCPUMillis := int64(offer.CPU * 1000) // Convert cores to millicores
+		offerMemoryMB := int64(offer.RAM)         // Already in MB
+
+		if offerCPUMillis >= cpuMillis && offerMemoryMB >= memoryMB {
+			c.logger.Info("Selected optimal K8s offer",
+				zap.Int("kubeSizeID", offer.ID),
+				zap.String("name", offer.Name),
+				zap.Int("cpu", offer.CPU),
+				zap.Int("ram", offer.RAM),
+				zap.Float64("price", offer.Price),
+				zap.Int64("requiredCPUMillis", cpuMillis),
+				zap.Int64("requiredMemoryMB", memoryMB),
+			)
+			return offer.ID, nil
+		}
+	}
+
+	// If no suitable offer found (all in use or too small), try any available offer
+	for _, offer := range sortedOffers {
+		if !usedSizes[offer.ID] {
+			c.logger.Warn("No optimal size available, using first available size",
+				zap.Int("kubeSizeID", offer.ID),
+				zap.String("name", offer.Name),
+				zap.Int("cpu", offer.CPU),
+				zap.Int("ram", offer.RAM),
+				zap.Int64("requiredCPUMillis", cpuMillis),
+				zap.Int64("requiredMemoryMB", memoryMB),
+			)
+			return offer.ID, nil
+		}
+	}
+
+	// All sizes are in use - this is a VPSie limitation
+	return 0, fmt.Errorf("all K8s sizes are already in use by existing node groups (VPSie limitation)")
+}
+
+// calculatePodResources calculates the total resource requests for a pod
+func (c *DynamicNodeGroupCreator) calculatePodResources(pod *corev1.Pod) (cpu, memory resource.Quantity) {
+	cpu = resource.Quantity{}
+	memory = resource.Quantity{}
+
+	for _, container := range pod.Spec.Containers {
+		if cpuReq, ok := container.Resources.Requests[corev1.ResourceCPU]; ok {
+			cpu.Add(cpuReq)
+		}
+		if memReq, ok := container.Resources.Requests[corev1.ResourceMemory]; ok {
+			memory.Add(memReq)
+		}
+	}
+
+	// Include init containers (they run sequentially, so take max, not sum)
+	for _, container := range pod.Spec.InitContainers {
+		if cpuReq, ok := container.Resources.Requests[corev1.ResourceCPU]; ok {
+			if cpuReq.Cmp(cpu) > 0 {
+				cpu = cpuReq
+			}
+		}
+		if memReq, ok := container.Resources.Requests[corev1.ResourceMemory]; ok {
+			if memReq.Cmp(memory) > 0 {
+				memory = memReq
+			}
+		}
+	}
+
+	// If no requests specified, use minimal defaults (500m CPU, 256Mi memory)
+	if cpu.IsZero() {
+		cpu = resource.MustParse("500m")
+	}
+	if memory.IsZero() {
+		memory = resource.MustParse("256Mi")
+	}
+
+	return cpu, memory
 }

--- a/pkg/events/creator_test.go
+++ b/pkg/events/creator_test.go
@@ -21,7 +21,7 @@ func TestNewDynamicNodeGroupCreator(t *testing.T) {
 	logger := zap.NewNop()
 
 	t.Run("Creates with default template", func(t *testing.T) {
-		creator := NewDynamicNodeGroupCreator(fakeClient, logger, nil)
+		creator := NewDynamicNodeGroupCreator(fakeClient, nil, logger, nil)
 		if creator == nil {
 			t.Fatal("Expected creator to be created")
 			return
@@ -44,7 +44,7 @@ func TestNewDynamicNodeGroupCreator(t *testing.T) {
 			MaxNodes:            20,
 			DefaultDatacenterID: "dc-1",
 		}
-		creator := NewDynamicNodeGroupCreator(fakeClient, logger, template)
+		creator := NewDynamicNodeGroupCreator(fakeClient, nil, logger, template)
 		if creator.template.MinNodes != 2 {
 			t.Errorf("Expected MinNodes=2, got %d", creator.template.MinNodes)
 		}
@@ -59,7 +59,7 @@ func TestFindSuitableNodeGroup(t *testing.T) {
 	_ = v1alpha1.AddToScheme(scheme)
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 	logger := zap.NewNop()
-	creator := NewDynamicNodeGroupCreator(fakeClient, logger, nil)
+	creator := NewDynamicNodeGroupCreator(fakeClient, nil, logger, nil)
 	ctx := context.Background()
 
 	t.Run("Returns nil when no NodeGroups exist", func(t *testing.T) {
@@ -263,8 +263,9 @@ func TestCreateNodeGroupForPod(t *testing.T) {
 			DefaultDatacenterID: "dc-test",
 			DefaultOfferingIDs:  []string{"offering-1"},
 			ResourceIdentifier:  "test-cluster",
+			KubeSizeID:          1, // Static fallback for testing without VPSie client
 		}
-		creator := NewDynamicNodeGroupCreator(fakeClient, logger, template)
+		creator := NewDynamicNodeGroupCreator(fakeClient, nil, logger, template)
 
 		pod := &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{Name: "test-pod"},
@@ -303,8 +304,9 @@ func TestCreateNodeGroupForPod(t *testing.T) {
 			DefaultDatacenterID: "dc-default",
 			DefaultOfferingIDs:  []string{"offering-1"},
 			ResourceIdentifier:  "test-cluster",
+			KubeSizeID:          1, // Static fallback for testing without VPSie client
 		}
-		creator := NewDynamicNodeGroupCreator(fakeClient, logger, template)
+		creator := NewDynamicNodeGroupCreator(fakeClient, nil, logger, template)
 
 		pod := &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{Name: "test-pod"},
@@ -339,8 +341,9 @@ func TestCreateNodeGroupForPod(t *testing.T) {
 			DefaultDatacenterID: "dc-default",
 			DefaultOfferingIDs:  []string{"offering-1"},
 			ResourceIdentifier:  "test-cluster",
+			KubeSizeID:          1, // Static fallback for testing without VPSie client
 		}
-		creator := NewDynamicNodeGroupCreator(fakeClient, logger, template)
+		creator := NewDynamicNodeGroupCreator(fakeClient, nil, logger, template)
 
 		pod := &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{Name: "test-pod"},
@@ -391,7 +394,7 @@ func TestGenerateNodeGroupName(t *testing.T) {
 		template := &NodeGroupTemplate{
 			DefaultDatacenterID: "us-east-1",
 		}
-		creator := NewDynamicNodeGroupCreator(fakeClient, logger, template)
+		creator := NewDynamicNodeGroupCreator(fakeClient, nil, logger, template)
 
 		name := creator.generateNodeGroupName()
 		if !strings.HasPrefix(name, "auto-us-east-1-") {
@@ -403,7 +406,7 @@ func TestGenerateNodeGroupName(t *testing.T) {
 		template := &NodeGroupTemplate{
 			DefaultDatacenterID: "",
 		}
-		creator := NewDynamicNodeGroupCreator(fakeClient, logger, template)
+		creator := NewDynamicNodeGroupCreator(fakeClient, nil, logger, template)
 
 		name := creator.generateNodeGroupName()
 		if !strings.HasPrefix(name, "auto-default-") {
@@ -447,7 +450,7 @@ func TestValidateTemplate(t *testing.T) {
 			DefaultOfferingIDs:  []string{"offering-1"},
 			ResourceIdentifier:  "test-cluster",
 		}
-		creator := NewDynamicNodeGroupCreator(fakeClient, logger, template)
+		creator := NewDynamicNodeGroupCreator(fakeClient, nil, logger, template)
 
 		err := creator.ValidateTemplate()
 		if err != nil {
@@ -460,7 +463,7 @@ func TestValidateTemplate(t *testing.T) {
 			DefaultOfferingIDs: []string{"offering-1"},
 			ResourceIdentifier: "test-cluster",
 		}
-		creator := NewDynamicNodeGroupCreator(fakeClient, logger, template)
+		creator := NewDynamicNodeGroupCreator(fakeClient, nil, logger, template)
 
 		err := creator.ValidateTemplate()
 		if err == nil {
@@ -473,7 +476,7 @@ func TestValidateTemplate(t *testing.T) {
 			DefaultDatacenterID: "dc-1",
 			ResourceIdentifier:  "test-cluster",
 		}
-		creator := NewDynamicNodeGroupCreator(fakeClient, logger, template)
+		creator := NewDynamicNodeGroupCreator(fakeClient, nil, logger, template)
 
 		err := creator.ValidateTemplate()
 		if err == nil {
@@ -486,7 +489,7 @@ func TestValidateTemplate(t *testing.T) {
 			DefaultDatacenterID: "dc-1",
 			DefaultOfferingIDs:  []string{"offering-1"},
 		}
-		creator := NewDynamicNodeGroupCreator(fakeClient, logger, template)
+		creator := NewDynamicNodeGroupCreator(fakeClient, nil, logger, template)
 
 		err := creator.ValidateTemplate()
 		if err == nil {

--- a/pkg/webhook/nodegroup_validator.go
+++ b/pkg/webhook/nodegroup_validator.go
@@ -213,13 +213,14 @@ func (v *NodeGroupValidator) validateKubernetesVersion(ng *autoscalerv1alpha1.No
 	return nil
 }
 
-// validateOSImage validates the OS image ID
+// validateOSImage validates the OS image ID format if provided
 func (v *NodeGroupValidator) validateOSImage(ng *autoscalerv1alpha1.NodeGroup) error {
+	// OSImageID is optional - VPSie API will automatically select an appropriate OS image
 	if ng.Spec.OSImageID == "" {
-		return fmt.Errorf("spec.osImageId is required and cannot be empty")
+		return nil
 	}
 
-	// Basic format validation
+	// Basic format validation if provided
 	if !validOSImageRegex.MatchString(ng.Spec.OSImageID) {
 		return fmt.Errorf("spec.osImageId '%s' contains invalid characters", ng.Spec.OSImageID)
 	}

--- a/pkg/webhook/vpsienode_validator.go
+++ b/pkg/webhook/vpsienode_validator.go
@@ -172,13 +172,14 @@ func (v *VPSieNodeValidator) validateKubernetesVersion(vn *autoscalerv1alpha1.VP
 	return nil
 }
 
-// validateOSImage validates the OS image ID
+// validateOSImage validates the OS image ID format if provided
 func (v *VPSieNodeValidator) validateOSImage(vn *autoscalerv1alpha1.VPSieNode) error {
+	// OSImageID is optional - VPSie API will automatically select an appropriate OS image
 	if vn.Spec.OSImageID == "" {
-		return fmt.Errorf("spec.osImageId is required and cannot be empty")
+		return nil
 	}
 
-	// Basic format validation
+	// Basic format validation if provided
 	if !validVPSieNodeOSImageRegex.MatchString(vn.Spec.OSImageID) {
 		return fmt.Errorf("spec.osImageId '%s' contains invalid characters", vn.Spec.OSImageID)
 	}


### PR DESCRIPTION
## Summary

This PR implements intelligent, dynamic sizing for automatically provisioned nodes, eliminating the need for manual size specification while maintaining cost efficiency.

- **Make osImageID optional**: VPSie API now auto-selects appropriate OS image when not specified
- **Dynamic KubeSizeID selection**: Automatically select optimal instance size based on pod resource requirements (CPU/memory)
- **Intelligent size selection**: Selects the smallest (most cost-effective) size that can accommodate pod requirements
- **VPSie limitation workaround**: Handles VPSie API constraint that only one node group per size is allowed by checking existing groups and skipping in-use sizes
- **Graceful degradation**: Falls back to static KubeSizeID or next available size if optimal choice is unavailable
- **Added --kube-size-id CLI flag**: Optional fallback mechanism for static size selection when dynamic selection fails

## Implementation Details

### Key Changes
1. **Dynamic Selection Logic** (`pkg/events/creator.go`):
   - `SelectOptimalKubeSizeID()`: Fetches K8s offers from VPSie API and selects optimal size
   - `calculatePodResources()`: Extracts CPU/memory requirements from pod spec
   - Checks existing node groups to avoid duplicate sizes (VPSie limitation)

2. **API Integration**:
   - `pkg/controller/options.go`: Added optional `--kube-size-id` flag
   - `pkg/controller/manager.go`: Passes VPSie client to creator
   - `DynamicNodeGroupCreator`: Now accepts VPSie client for API access

3. **Configuration**:
   - `cmd/controller/main.go`: Added CLI flag definition
   - `deploy/manifests/deployment.yaml`: Updated container args

4. **Documentation**:
   - `docs/TODO_WORKAROUNDS.md`: Documents VPSie limitation and removal plan

## Testing

Run unit tests:
```bash
make test
```

The implementation includes:
- Proper error handling with fallback to static KubeSizeID
- Logging at each decision point for debugging
- Resource request parsing including init containers
- Default resources (500m CPU, 256Mi memory) for pods without explicit requests

## Version Changes

This spans versions v0.7.5 through v0.7.8:
- **v0.7.5**: Made osImageID optional
- **v0.7.6**: Added static KubeSizeID support with CLI flag
- **v0.7.7**: Added dynamic KubeSizeID selection logic
- **v0.7.8**: Added workaround for VPSie size limitation

## Migration Notes

No breaking changes. Existing configurations continue to work:
- If `--kube-size-id` is provided, it's used as fallback
- If `--kube-size-id` is not provided, dynamic selection attempts to find optimal size
- osImageID can now be omitted (VPSie API will auto-select)

## Files Changed

- `cmd/controller/main.go`: Added CLI flag
- `pkg/controller/options.go`: Added KubeSizeID field
- `pkg/controller/manager.go`: Pass VPSie client to creator
- `pkg/events/creator.go`: Implement dynamic selection logic
- `pkg/webhook/nodegroup_validator.go`: Update validation
- `deploy/crds/*.yaml`: Generated OpenAPI schemas
- `docs/TODO_WORKAROUNDS.md`: New file documenting workaround