### PR TITLE
feat: same-nodegroup protection, creation reason tracking, and code quality improvements

### DIFF
--- a/pkg/controller/vpsienode/provisioner.go
+++ b/pkg/controller/vpsienode/provisioner.go
@@ -314,6 +314,13 @@ func (p *Provisioner) Delete(ctx context.Context, vn *v1alpha1.VPSieNode, logger
 			if err != nil {
 				logger.Warn("Failed to look up node identifier, will try other deletion methods",
 					zap.String("vpsienode", vn.Name),
+					zap.String("vpsieNodeIdentifier", vn.Spec.VPSieNodeIdentifier),
+					zap.String("statusHostname", vn.Status.Hostname),
+					zap.String("specNodeName", vn.Spec.NodeName),
+					zap.String("statusNodeName", vn.Status.NodeName),
+					zap.String("hostnameUsed", hostname),
+					zap.String("resourceIdentifier", vn.Spec.ResourceIdentifier),
+					zap.Int("vpsieInstanceID", vn.Spec.VPSieInstanceID),
 					zap.Error(err),
 				)
 			} else if lookedUpID != "" {
@@ -325,7 +332,13 @@ func (p *Provisioner) Delete(ctx context.Context, vn *v1alpha1.VPSieNode, logger
 			} else {
 				logger.Warn("Node not found in cluster info, may already be deleted",
 					zap.String("vpsienode", vn.Name),
-					zap.String("hostname", hostname),
+					zap.String("vpsieNodeIdentifier", vn.Spec.VPSieNodeIdentifier),
+					zap.String("statusHostname", vn.Status.Hostname),
+					zap.String("specNodeName", vn.Spec.NodeName),
+					zap.String("statusNodeName", vn.Status.NodeName),
+					zap.String("hostnameUsed", hostname),
+					zap.String("resourceIdentifier", vn.Spec.ResourceIdentifier),
+					zap.Int("vpsieInstanceID", vn.Spec.VPSieInstanceID),
 				)
 			}
 		}
@@ -415,7 +428,12 @@ func (p *Provisioner) Delete(ctx context.Context, vn *v1alpha1.VPSieNode, logger
 	return nil
 }
 
-// generateHostname generates a hostname for the VPS
+// generateHostname generates a hostname for the VPS.
+// This function is used as a fallback when updating VPSieNode spec after VPS creation,
+// specifically when both vn.Spec.NodeName is empty AND the VPSie API does not return
+// a hostname (vps.Hostname is empty). In practice, VPSie API usually provides the
+// hostname, but this fallback ensures we always have a valid NodeName set.
+// See UpdateVPSieNodeFromVPS where this is called.
 func (p *Provisioner) generateHostname(vn *v1alpha1.VPSieNode) string {
 	if vn.Spec.NodeName != "" {
 		return vn.Spec.NodeName


### PR DESCRIPTION
## Summary

This PR introduces same-nodegroup protection during rebalancing, creation reason tracking for nodes, and various code quality improvements.

### Key Features
- **Same-NodeGroup Protection**: Prevents rebalancer from migrating nodes within the same nodegroup
- **Creation Reason Tracking**: Adds label tracking why nodes were created (metrics, manual, rebalance, initial)
- **AutoscalerConfig CRD**: Cluster-wide configuration with automatic sync to managed NodeGroups
- **Code Review Fixes**: Improved error handling, logging, and code clarity

### Changes Include
- Add autoscaler.vpsie.com/creation-reason label for tracking node creation source
- Implement same-nodegroup protection in rebalancer analyzer
- Add AutoscalerConfig CRD with GlobalSettings and NodeGroupDefaults
- Sync all policy settings (ScaleUp, ScaleDown, CostOptimization, SpotConfig) to NodeGroups
- Enable node deletion by hostname lookup during scale-down
- Replace string-based conflict detection with apierrors.IsConflict
- Add exponential backoff for retry logic
- Enhanced logging with all attempted identifiers for debugging
- Add documentation to equality functions

## Test plan
- [x] All unit tests pass
- [x] Build succeeds
- [x] Linting passes
- [ ] Deploy to test cluster and verify NodeGroup sync
- [ ] Verify node creation reason labels are applied
- [ ] Test scale-down with hostname-based deletion