### PR TITLE
docs: update container image registry to ghcr.io/vpsieinc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -394,7 +394,7 @@ This release establishes the complete foundation for the VPSie Kubernetes Autosc
   - CRD manifest freshness verification
 - Docker multi-arch builds (linux/amd64, linux/arm64)
   - Automated builds on push to main and version tags
-  - Published to ghcr.io/vpsie/vpsie-k8s-autoscaler
+  - Published to ghcr.io/vpsieinc/vpsie-k8s-autoscaler
   - Version information injection via ldflags
   - Distroless base image for minimal attack surface
 - Makefile with comprehensive targets
@@ -453,9 +453,9 @@ See [OAUTH_MIGRATION.md](OAUTH_MIGRATION.md) for migration guide.
 ### Docker Images
 
 Published to GitHub Container Registry:
-- `ghcr.io/vpsie/vpsie-k8s-autoscaler:latest`
-- `ghcr.io/vpsie/vpsie-k8s-autoscaler:main`
-- `ghcr.io/vpsie/vpsie-k8s-autoscaler:v0.1.0-alpha` (planned)
+- `ghcr.io/vpsieinc/vpsie-k8s-autoscaler:latest`
+- `ghcr.io/vpsieinc/vpsie-k8s-autoscaler:main`
+- `ghcr.io/vpsieinc/vpsie-k8s-autoscaler:v0.1.0-alpha` (planned)
 
 Multi-architecture support:
 - linux/amd64

--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -33,7 +33,7 @@
 4. **CI/CD & Infrastructure**
    - ✅ GitHub Actions CI workflow (test, lint, build, verify-crds)
    - ✅ Docker multi-arch builds (linux/amd64, linux/arm64)
-   - ✅ Automated image publishing to ghcr.io/vpsie/vpsie-k8s-autoscaler
+   - ✅ Automated image publishing to ghcr.io/vpsieinc/vpsie-k8s-autoscaler
    - ✅ 72 total tests with 81.5% overall coverage
    - ✅ Pre-commit hooks for code quality
    - ✅ All workflows passing with zero failures

--- a/deploy/webhook/deployment.yaml
+++ b/deploy/webhook/deployment.yaml
@@ -25,7 +25,7 @@ spec:
 
       containers:
         - name: webhook
-          image: vpsie/k8s-autoscaler-webhook:latest
+          image: vpsieinc/vpsie-k8s-autoscaler-webhook:latest
           imagePullPolicy: IfNotPresent
 
           ports:

--- a/deployments/README.md
+++ b/deployments/README.md
@@ -144,7 +144,7 @@ kubectl get --raw /api/v1/namespaces/vpsie-system/services/vpsie-autoscaler-metr
 
 ```bash
 kubectl kustomize deployments/overlays/production/ | \
-  kubectl patch --local -f - -p '{"spec":{"template":{"spec":{"containers":[{"name":"controller","image":"ghcr.io/vpsie/vpsie-k8s-autoscaler:v0.5.0"}]}}}}' --type=strategic -o yaml | \
+  kubectl patch --local -f - -p '{"spec":{"template":{"spec":{"containers":[{"name":"controller","image":"ghcr.io/vpsieinc/vpsie-k8s-autoscaler:v0.5.0"}]}}}}' --type=strategic -o yaml | \
   kubectl apply -f -
 ```
 

--- a/deployments/base/deployment.yaml
+++ b/deployments/base/deployment.yaml
@@ -47,7 +47,7 @@ spec:
               topologyKey: kubernetes.io/hostname
       containers:
       - name: controller
-        image: ghcr.io/vpsie/vpsie-k8s-autoscaler:v0.4.0-alpha
+        image: ghcr.io/vpsieinc/vpsie-k8s-autoscaler:v0.4.0-alpha
         imagePullPolicy: IfNotPresent
         command:
         - /vpsie-autoscaler

--- a/deployments/base/kustomization.yaml
+++ b/deployments/base/kustomization.yaml
@@ -22,7 +22,7 @@ resources:
 
 # Images to use (can be overridden in overlays)
 images:
-  - name: ghcr.io/vpsie/vpsie-k8s-autoscaler
+  - name: ghcr.io/vpsieinc/vpsie-k8s-autoscaler
     newTag: v0.4.0-alpha
 
 # ConfigMap generator for shared configuration

--- a/deployments/overlays/dev/kustomization.yaml
+++ b/deployments/overlays/dev/kustomization.yaml
@@ -75,7 +75,7 @@ patches:
 
 # Override image tag for dev (use latest or dev tag)
 images:
-  - name: ghcr.io/vpsie/vpsie-k8s-autoscaler
+  - name: ghcr.io/vpsieinc/vpsie-k8s-autoscaler
     newTag: latest
 
 # ConfigMap overrides for dev

--- a/deployments/overlays/production/kustomization.yaml
+++ b/deployments/overlays/production/kustomization.yaml
@@ -94,7 +94,7 @@ patches:
 
 # Use production-specific image tag (pin to specific version)
 images:
-  - name: ghcr.io/vpsie/vpsie-k8s-autoscaler
+  - name: ghcr.io/vpsieinc/vpsie-k8s-autoscaler
     newTag: v0.4.0
 
 # Production ConfigMap

--- a/deployments/overlays/staging/kustomization.yaml
+++ b/deployments/overlays/staging/kustomization.yaml
@@ -70,7 +70,7 @@ patches:
 
 # Use staging-specific image tag
 images:
-  - name: ghcr.io/vpsie/vpsie-k8s-autoscaler
+  - name: ghcr.io/vpsieinc/vpsie-k8s-autoscaler
     newTag: v0.4.0-alpha
 
 # ConfigMap overrides for staging

--- a/prompts
+++ b/prompts
@@ -184,7 +184,7 @@ maintainers:
 replicaCount: 1  # Use 2+ for HA with leader election
 
 image:
-  repository: ghcr.io/vpsie/vpsie-k8s-autoscaler
+  repository: ghcr.io/vpsieinc/vpsie-k8s-autoscaler
   pullPolicy: IfNotPresent
   tag: "latest"
 
@@ -396,7 +396,7 @@ spec:
       serviceAccountName: vpsie-autoscaler
       containers:
       - name: controller
-        image: ghcr.io/vpsie/vpsie-k8s-autoscaler:latest
+        image: ghcr.io/vpsieinc/vpsie-k8s-autoscaler:latest
         args:
           - --metrics-addr=:8080
           - --health-addr=:8081
@@ -426,7 +426,7 @@ configMapGenerator:
       - config.yaml
 
 images:
-  - name: ghcr.io/vpsie/vpsie-k8s-autoscaler
+  - name: ghcr.io/vpsieinc/vpsie-k8s-autoscaler
     newTag: v1.0.0
 ```
 


### PR DESCRIPTION
## Summary

Update all container image references from `ghcr.io/vpsie/vpsie-k8s-autoscaler` to `ghcr.io/vpsieinc/vpsie-k8s-autoscaler` to match the GitHub organization namespace.

## Changes

- Updated image registry in deployment manifests
- Updated image registry in kustomization files (base, dev, staging, production)
- Updated image registry in documentation (CHANGELOG.md, NEXT_STEPS.md, README.md)
- Updated webhook image reference

## Files Changed
- CHANGELOG.md
- NEXT_STEPS.md  
- deployments/base/deployment.yaml
- deployments/base/kustomization.yaml
- deployments/overlays/dev/kustomization.yaml
- deployments/overlays/production/kustomization.yaml
- deployments/overlays/staging/kustomization.yaml
- deployments/README.md
- deploy/webhook/deployment.yaml
- prompts

## Test plan
- [x] All tests pass
- [x] Build succeeds